### PR TITLE
Remove non-root user from Pathfinder image

### DIFF
--- a/deps/pathfinder/Dockerfile
+++ b/deps/pathfinder/Dockerfile
@@ -38,17 +38,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a non-root user
-RUN groupadd --gid 1000 pathfinder && \
-    useradd --no-log-init --uid 1000 --gid pathfinder --no-create-home pathfinder
-
 # Set up working directory
 WORKDIR /usr/local/bin
 COPY --from=builder /pathfinder/target/release/pathfinder /usr/local/bin/pathfinder
-
-# Set ownership and permissions
-RUN chown -R pathfinder:pathfinder /usr/local/bin/pathfinder
-USER pathfinder
 
 # Expose RPC port
 EXPOSE 9545


### PR DESCRIPTION
Running Pathfinder as a non-root user caused a permission issue (in linux) when attempting to write to the mounted database folder. This error led to the immediate termination of the Pathfinder service, which in turn resulted in the following MongoDB error for SNOS job. However, the root cause was that Pathfinder was not running.

> "failure_reason": "Processing failed: Snos Error: Error while running SNOS (snos job #\"1\"): RPC Error: error sending request for url (http://pathfinder:9545/rpc/v0_7): error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution"