### PR TITLE
Update prover image to support different arch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deps/madara"]
 	path = deps/madara
 	url = https://github.com/madara-alliance/madara.git
+	commit = bb89d4971fb92215ac49e6e3d6b5a0b92b748f9b

--- a/crates/madara/src/commands/orchestrator.rs
+++ b/crates/madara/src/commands/orchestrator.rs
@@ -154,9 +154,14 @@ fn populate_orchestrator_compose(prover_config: &ProverRunnerConfig) -> anyhow::
 
     // Set up MiniJinja
     let mut env = Environment::new();
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    let prover_image = "gustavomoonsong/mock-prover-amd64";
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    let prover_image = "gustavomoonsong/mock-prover-arm64";
     env.add_template("compose_template", &template)
         .expect("Failed to add template");
-    let data = context! {ENABLE_DUMMY_PROVER => prover_config.prover_type == ProverType::Dummy};
+    let data = context! {ENABLE_DUMMY_PROVER => prover_config.prover_type == ProverType::Dummy,
+    MADARA_PROVER_IMAGE => prover_image};
 
     // Render the template
     let tmpl = env.get_template("compose_template").unwrap();

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -104,7 +104,7 @@ services:
 
 {%- if ENABLE_DUMMY_PROVER %}
   prover:
-    image: ocdbytes/mock-prover:latest
+    image: {{ MADARA_PROVER_IMAGE }}
     container_name: prover
     ports:
       - "6000:6000"


### PR DESCRIPTION
Change the image being pulled from dockerhub to support arm64 and amd64 architectures.