### PR TITLE
chore: add to gitignore madara container artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 deps/orchestrator/.env
 deps/orchestrator/run_orchestrator.sh
 deps/compose.yaml
+deps/data/*

--- a/crates/config/src/madara.rs
+++ b/crates/config/src/madara.rs
@@ -166,7 +166,7 @@ impl MadaraRunnerConfigSequencer {
 impl Default for MadaraRunnerConfigSequencer {
     fn default() -> Self {
         Self {
-            base_path: Some("madara/data".to_string()),
+            base_path: Some("data/madara".to_string()),
             chain_config_path: Some("configs/presets/devnet.yaml".to_string()),
         }
     }

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -64,7 +64,7 @@ services:
       madara:
         condition: service_started
     volumes:
-      - ./pathfinder/data:/usr/share/pathfinder/data
+      - ./data/pathfinder:/usr/share/pathfinder/data
       - ./pathfinder/pathfinder-runner.sh:/usr/local/bin/runner.sh:ro
     entrypoint:
       - /usr/local/bin/runner.sh

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -36,7 +36,7 @@ services:
       core_contract_deployment:
         condition: service_completed_successfully
     volumes:
-      - ./madara/data:/usr/share/madara/data
+      - ./data/madara:/usr/share/madara/data
       - ./madara/madara-runner.sh:/usr/local/bin/runner.sh:ro
       - ./madara/configs/presets:/usr/local/bin/configs/presets
     entrypoint:

--- a/deps/pathfinder/.gitignore
+++ b/deps/pathfinder/.gitignore
@@ -1,2 +1,1 @@
 pathfinder-runner.sh
-data/


### PR DESCRIPTION
This PR adds all artifacts generated when running the Madara container to .gitignore, preventing untracked files from appearing in Git's working tree.

- Changed the local mount path from `deps/madara/data` to `deps/data/madara` (moved out of the submodule directory).
- Updated .gitignore.