### PR TITLE
Fix Madara as sequencer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ By using this CLI, you can streamline the node setup process and quickly get sta
 ## Usage
 To create a custom configuration for AppChain, use:
   ```bash
-  cargo run init
+  cargo run init [--default]
   ```
 This command will allow the user to start from the template configuration to spin up a local AppChain and change all the parameters.
+Use `default` flag to skip user interaction in this command. This will basically create a configuration file that clones the template.
 
 To run the CLI and spin up Madara, use:
   ```bash

--- a/crates/madara/src/commands/madara.rs
+++ b/crates/madara/src/commands/madara.rs
@@ -134,7 +134,7 @@ fn create_runner_script(
 
 fn check_secrets(mode: MadaraMode) -> anyhow::Result<()> {
     match mode {
-        MadaraMode::Sequencer | MadaraMode::FullNode => {
+        MadaraMode::FullNode => {
             let rpc_api_secret = PathBuf::new()
                 .join(MADARA_REPO_PATH)
                 .join(MADARA_RPC_API_KEY_FILE);
@@ -163,7 +163,7 @@ fn check_secrets(mode: MadaraMode) -> anyhow::Result<()> {
                 fs::write(rpc_api_secret, rpc_api_url)?;
             }
         }
-        MadaraMode::Devnet => {
+        MadaraMode::Devnet | MadaraMode::Sequencer => {
             let rpc_api_secret = PathBuf::new()
                 .join(MADARA_REPO_PATH)
                 .join(MADARA_RPC_API_KEY_FILE);
@@ -233,7 +233,13 @@ fn parse_sequencer_params(
         .clone()
         .expect("Chain config file must be set");
 
-    // TODO: handle optional params.
+    let l1_config = params
+        .l1_endpoint
+        .clone()
+        .map_or("--no-l1-sync".to_string(), |endpoint| {
+            format!("--l1-endpoint {}", endpoint)
+        });
+
     let sequencer_params = vec![
         format!("--name {}", name),
         format!("--{}", mode).to_lowercase(),
@@ -248,7 +254,7 @@ fn parse_sequencer_params(
         "--gas-price 10".to_string(),
         "--blob-gas-price 20".to_string(),
         "--gateway-port 8080".to_string(),
-        "--l1-endpoint http://anvil:8545".to_string(),
+        l1_config,
     ];
 
     Ok(sequencer_params)

--- a/deps/madara/compose.yaml
+++ b/deps/madara/compose.yaml
@@ -17,10 +17,11 @@ services:
     volumes:
       - ${MADARA_DATA_DIR}:/tmp/madara
       - ./madara-runner.sh:/usr/local/bin/runner.sh:ro
+      - ./configs/presets:/usr/local/bin/configs/presets
     entrypoint:
       - /usr/local/bin/runner.sh
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9944/health"]
+      test: [ "CMD", "curl", "-f", "http://localhost:9944/health" ]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Some fixes to deploy Madara as Sequencer
- Preset folder was mounted in the container
- L1 endpoint param was added. If the user doesn't set one, the sequencer will spin up with no l1-sync
- Allow the user to define the DB folder's name

Closes #19 