### PR TITLE
fix: Orchestrator start

### DIFF
--- a/deps/compose.template
+++ b/deps/compose.template
@@ -156,12 +156,11 @@ services:
       - ./orchestrator/run_orchestrator.sh:/usr/local/bin/run_orchestrator.sh
     entrypoint:
       - /usr/local/bin/run_orchestrator.sh
-{%- if ENABLE_BOOTSTRAPER_L2_SETUP %}
     depends_on:
+{%- if ENABLE_BOOTSTRAPER_L2_SETUP %}
       bootstrapper_l2:
         condition: service_completed_successfully
 {%- endif %}
-    depends_on:
       localstack:
         condition: service_healthy 
     attach: false

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -127,6 +127,11 @@ services:
     depends_on:
       madara:
         condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
     attach: false
 
 {%- if ENABLE_DUMMY_PROVER %}
@@ -156,4 +161,7 @@ services:
       bootstrapper_l2:
         condition: service_completed_successfully
 {%- endif %}
+    depends_on:
+      localstack:
+        condition: service_healthy 
     attach: false

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -157,10 +157,8 @@ services:
     entrypoint:
       - /usr/local/bin/run_orchestrator.sh
     depends_on:
-{%- if ENABLE_BOOTSTRAPER_L2_SETUP %}
       bootstrapper_l2:
         condition: service_completed_successfully
-{%- endif %}
       localstack:
         condition: service_healthy 
     attach: false


### PR DESCRIPTION
Orchestrator now waits until localstack is healthy before running