### PR TITLE
Dynamic addresses propagation

### DIFF
--- a/crates/madara/src/commands/madara.rs
+++ b/crates/madara/src/commands/madara.rs
@@ -105,6 +105,10 @@ fn create_runner_script(
             script.push_str("  exit 1\n");
             script.push_str("fi\n\n");
         }
+        MadaraMode::AppChain => {
+            script.push_str("./scripts/update_config.sh configs/presets/devnet.yaml madara\n");
+            script.push_str("\n");
+        }
         _ => {}
     }
 

--- a/crates/madara/src/main.rs
+++ b/crates/madara/src/main.rs
@@ -85,9 +85,17 @@ fn init_global_config_inner(_shell: &Shell, madara_args: &MadaraGlobalArgs) -> a
 }
 
 fn init_data_directory() -> anyhow::Result<()> {
+    // Create data folder
     let deps_data_dir = Path::new(DEFAULT_TMP_DATA_DIRECTORY);
     if !deps_data_dir.exists() {
         fs::create_dir_all(deps_data_dir).expect("Unable to create data directory");
     }
+
+    // Create env file
+    let env_file_path = deps_data_dir.join(".env");
+    if !env_file_path.exists() {
+        fs::write(&env_file_path, "")?;
+    }
+
     Ok(())
 }

--- a/deps/anvil/Dockerfile
+++ b/deps/anvil/Dockerfile
@@ -28,7 +28,7 @@ ENV PATH="/root/.foundry/bin:${PATH}"
 WORKDIR /app
 
 # Install Starknet and Ethers.js
-RUN npm install starknet ethers
+RUN npm install starknet ethers dotenv
 
 # Copy files into the image
 COPY MockGPSVerifier.sol /app/

--- a/deps/anvil/mock_verifier_contract.sh
+++ b/deps/anvil/mock_verifier_contract.sh
@@ -35,3 +35,6 @@ fi
 # Extract contract address from forge create output
 VERIFIER_ADDRESS=$(echo "$VERIFIER_RESULT" | grep "Deployed to" | awk '{print $3}')
 echo -e "📦 Verifier deployed at: $VERIFIER_ADDRESS\n"
+
+# Update env file with verifier address
+echo "verifier_address=\"$VERIFIER_ADDRESS\"" > data/.env

--- a/deps/anvil/override_state.js
+++ b/deps/anvil/override_state.js
@@ -2,6 +2,7 @@
 /// override the state on the core contract
 const starknet = require("starknet");
 const ethers = require("ethers");
+const dotenv = require("dotenv");
 
 // Using anvil key with funds
 const MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY = process.env.MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY;
@@ -66,7 +67,10 @@ async function overrideStateOnCoreContract(
 
 async function main() {
   let block_number = await starknet_provider.getBlockNumber();
-  let core_contract_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+  // Load environment variables
+  dotenv.config();
+  let core_contract_address = process.env.starknet_contract_address;
+  console.log("Core contract address: ", core_contract_address);
   await overrideStateOnCoreContract(block_number, core_contract_address)
 }
 

--- a/deps/bootstrapper/Dockerfile
+++ b/deps/bootstrapper/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     libboost-all-dev \
     wget \
+    jq \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deps/bootstrapper/Dockerfile
+++ b/deps/bootstrapper/Dockerfile
@@ -128,7 +128,7 @@ RUN npm install -g --unsafe-perm ganache@7.9.0
 
 WORKDIR /app
 
-RUN git clone --branch ft/makefile_fix --recurse-submodules https://github.com/madara-alliance/madara-bootstrapper.git .
+RUN git clone --branch main --recurse-submodules https://github.com/madara-alliance/madara-bootstrapper.git .
 
 RUN make setup-linux
 

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -85,6 +85,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./anvil/override_state.js:/app/override_state.js
+      - ./data/.env:/app/.env
     environment:
       MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY: {{ ETH_PRIV_KEY }}
     command: -c "node override_state.js"
@@ -158,6 +159,7 @@ services:
     volumes:
       - ./orchestrator/.env:/usr/local/bin/.env_tmp
       - ./orchestrator/run_orchestrator.sh:/usr/local/bin/run_orchestrator.sh
+      - ./data/.env:/usr/local/bin/.env_vars
     entrypoint:
       - /usr/local/bin/run_orchestrator.sh
 {%- if ENABLE_BOOTSTRAPER_L2_SETUP %}

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -53,8 +53,7 @@ services:
       - ./madara/madara-runner.sh:/usr/local/bin/runner.sh:ro
       - ./madara/configs/presets:/usr/local/bin/configs/presets
       - ./scripts/:/usr/local/bin/scripts
-    env_file:
-      - ./data/.env      
+      - ./data/:/usr/local/bin/data
     entrypoint:
       - /usr/local/bin/runner.sh
     restart: unless-stopped

--- a/deps/compose.template
+++ b/deps/compose.template
@@ -16,20 +16,25 @@ services:
     entrypoint: /bin/bash
     volumes:
       - ./anvil/mock_verifier_contract.sh:/app/mock_verifier_contract.sh
+      - ./data/:/app/data
     depends_on:
       anvil:
         condition: service_started
     command: -c "sleep 5 && ./mock_verifier_contract.sh {{ ETH_PRIV_KEY }}"
 
   bootstrapper_l1:
-    image: {{ IMAGE_REPOSITORY }}bootstrapper:latest
+    image: bootstrapper:latest
     container_name: bootstrapper_l1
     depends_on:
       mock_verifier_contract:
         condition: service_completed_successfully
     volumes:
-      - ./bootstrapper/devnet.json:/app/src/configs/devnet.json
-    command: -c "sleep 5 && cargo run --release -- --mode setup-l1 --config src/configs/devnet.json"
+      - ./bootstrapper/:/app/bootstrapper
+      - ./data/:/app/data
+      - ./scripts/:/app/scripts
+    env_file:
+      - ./data/.env
+    command: -c "./scripts/update_config.sh bootstrapper/devnet.json bootstrapper_l1 && sleep 2 && cargo run --release -- --mode setup-l1 --config bootstrapper/devnet.json --output-file ./bootstrapper_l1.json && scripts/json_to_env.sh bootstrapper_l1.json"
     attach: false
   
   madara:
@@ -47,20 +52,25 @@ services:
       - ./data/madara:/usr/share/madara/data
       - ./madara/madara-runner.sh:/usr/local/bin/runner.sh:ro
       - ./madara/configs/presets:/usr/local/bin/configs/presets
+      - ./scripts/:/usr/local/bin/scripts
+    env_file:
+      - ./data/.env      
     entrypoint:
       - /usr/local/bin/runner.sh
     restart: unless-stopped
 
   bootstrapper_l2:
-    image: {{ IMAGE_REPOSITORY }}bootstrapper:latest
+    image: bootstrapper:latest
     container_name: bootstrapper_l2
     depends_on:
       madara:
         condition: service_started
     volumes:
-      - ./bootstrapper/devnet.json:/app/src/configs/devnet.json
+      - ./bootstrapper/:/app/bootstrapper
+      - ./data/:/app/data
+      - ./scripts/:/app/scripts
 {%- if ENABLE_BOOTSTRAPER_L2_SETUP %}
-    command: -c "sleep 5 && cargo run --release -- --mode setup-l2 --config src/configs/devnet.json"
+    command: -c "./scripts/update_config.sh bootstrapper/devnet.json bootstrapper_l2 && sleep 2 && cargo run --release -- --mode setup-l2 --config bootstrapper/devnet.json --output-file bootstrapper_l2.json && scripts/json_to_env.sh bootstrapper_l2.json"
 {%- else %}
     command: -c "sleep 5 && echo 'Bootstrapper L2 contracts are disabled'"
 {%- endif %}

--- a/deps/orchestrator/Dockerfile
+++ b/deps/orchestrator/Dockerfile
@@ -13,10 +13,10 @@ RUN apt update && apt install -y  \
 # Set the working directory
 WORKDIR /usr/src
 
-# Clone the specific branch of the repository
-RUN git clone --branch unignore_cargo_lock --depth 1 https://github.com/madara-alliance/madara-orchestrator.git
+# Clone the repository
+RUN git clone --branch main --depth 1 https://github.com/madara-alliance/madara.git
 
-WORKDIR /usr/src/madara-orchestrator
+WORKDIR /usr/src/madara
 
 # Install Python 3.9
 RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
@@ -43,19 +43,16 @@ RUN cargo fetch
 RUN python3.9 -m venv orchestrator_venv
 RUN . ./orchestrator_venv/bin/activate
 RUN pip install cairo-lang==0.13.2 "sympy<1.13.0"
-RUN mkdir -p build
+RUN mkdir -p orchestrator/build
 RUN git submodule update --init --recursive
-RUN cd cairo-lang
-RUN cd ..
-RUN cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
+RUN cairo-compile orchestrator/cairo-lang/src/starkware/starknet/core/os/os.cairo --output orchestrator/build/os_latest.json --cairo_path orchestrator/cairo-lang/src
 # #############################################################
 
 # Build the project
-RUN cargo build --release
+RUN cargo build --bin orchestrator --release
 
 # Install Node.js dependencies for migrations
-RUN npm install
-
+RUN cd orchestrator && npm install
 
 FROM debian:bookworm
 
@@ -70,22 +67,24 @@ RUN apt-get -y update && \
 WORKDIR /usr/local/bin
 
 # Copy the compiled binary from the builder stage
-COPY --from=builder /usr/src/madara-orchestrator/target/release/orchestrator .
+COPY --from=builder /usr/src/madara/target/release/orchestrator .
 
 # Copy Node.js files and dependencies
-COPY --from=builder /usr/src/madara-orchestrator/node_modules ./node_modules
-COPY --from=builder /usr/src/madara-orchestrator/package.json .
-COPY --from=builder /usr/src/madara-orchestrator/migrate-mongo-config.js .
-COPY --from=builder /usr/src/madara-orchestrator/migrations ./migrations
+COPY --from=builder /usr/src/madara/orchestrator/node_modules ./node_modules
+COPY --from=builder /usr/src/madara/orchestrator/package.json .
+COPY --from=builder /usr/src/madara/orchestrator/migrate-mongo-config.js .
+COPY --from=builder /usr/src/madara/orchestrator/migrations ./migrations
 
-# To be fixed by this https://github.com/keep-starknet-strange/snos/issues/404
+# # To be fixed by this https://github.com/keep-starknet-strange/snos/issues/404
 RUN mkdir -p /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/662d170/crates/starknet-os/kzg
 RUN mkdir -p /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/ea7d63f/crates/starknet-os/kzg
 RUN mkdir -p /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/2c47281/crates/starknet-os/kzg
+RUN mkdir -p /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/8acf974/crates/starknet-os/kzg
 
-COPY --from=builder /usr/src/madara-orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/662d170/crates/starknet-os/kzg/trusted_setup.txt
-COPY --from=builder /usr/src/madara-orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/ea7d63f/crates/starknet-os/kzg/trusted_setup.txt
-COPY --from=builder /usr/src/madara-orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/2c47281/crates/starknet-os/kzg/trusted_setup.txt
-COPY --from=builder /usr/src/madara-orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/src/madara-orchestrator/crates/settlement-clients/ethereum/src/trusted_setup.txt
+COPY --from=builder /usr/src/madara/orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/662d170/crates/starknet-os/kzg/trusted_setup.txt
+COPY --from=builder /usr/src/madara/orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/ea7d63f/crates/starknet-os/kzg/trusted_setup.txt
+COPY --from=builder /usr/src/madara/orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/2c47281/crates/starknet-os/kzg/trusted_setup.txt
+COPY --from=builder /usr/src/madara/orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/local/cargo/git/checkouts/snos-59fe8329bb16fe65/8acf974/crates/starknet-os/kzg/trusted_setup.txt
+COPY --from=builder /usr/src/madara/orchestrator/crates/da-clients/ethereum/trusted_setup.txt /usr/src/madara/orchestrator/crates/settlement-clients/ethereum/src/trusted_setup.txt
 
 ENTRYPOINT ["/bin/bash"]

--- a/deps/orchestrator/run_orchestrator.template
+++ b/deps/orchestrator/run_orchestrator.template
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Configure Orchestrator to start on the following block after Bootstrapper finishes the L2 configuration
 # RPC call to get Madara last block and then replace the MIN_BLOCK from .env file with X+1 value
@@ -17,7 +17,13 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Block number: $LAST_BLOCK_NUMBER"
-awk -v val="$LAST_BLOCK_NUMBER" '/MADARA_ORCHESTRATOR_MIN_BLOCK_NO_TO_PROCESS=/{$0="MADARA_ORCHESTRATOR_MIN_BLOCK_NO_TO_PROCESS="val}1' .env_tmp > .new_env && mv .new_env .env
+source .env_vars
+sed -e "s/^MADARA_ORCHESTRATOR_MIN_BLOCK_NO_TO_PROCESS=.*/MADARA_ORCHESTRATOR_MIN_BLOCK_NO_TO_PROCESS=$LAST_BLOCK_NUMBER/" \
+    -e "s/^MADARA_ORCHESTRATOR_GPS_VERIFIER_CONTRACT_ADDRESS=.*/MADARA_ORCHESTRATOR_GPS_VERIFIER_CONTRACT_ADDRESS=$verifier_address/" \
+    -e "s/^MADARA_ORCHESTRATOR_ATLANTIC_VERIFIER_CONTRACT_ADDRESS=.*/MADARA_ORCHESTRATOR_ATLANTIC_VERIFIER_CONTRACT_ADDRESS=$verifier_address/" \
+    -e "s/^MADARA_ORCHESTRATOR_L1_CORE_CONTRACT_ADDRESS=.*/MADARA_ORCHESTRATOR_L1_CORE_CONTRACT_ADDRESS=$starknet_contract_address/" \
+    -e "s/^MADARA_ORCHESTRATOR_MAX_BLOCK_NO_TO_PROCESS=.*/MADARA_ORCHESTRATOR_MAX_BLOCK_NO_TO_PROCESS=${MADARA_ORCHESTRATOR_MAX_BLOCK_NO_TO_PROCESS:-}/" \
+    .env_tmp > .env
 
 # Orchestrator setup
 ./orchestrator setup --aws --aws-s3 --aws-sqs --aws-sns --aws-event-bridge --event-bridge-type {{ EVENT_BRIDGE_TYPE | default("rule") }}

--- a/deps/scripts/json_to_env.sh
+++ b/deps/scripts/json_to_env.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if jq is installed
+if ! command -v jq &>/dev/null; then
+    echo "jq is required but not installed. Install it and try again."
+    exit 1
+fi
+
+# Check for input JSON file
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <json_file>"
+    exit 1
+fi
+
+JSON_FILE="$1"
+OUTPUT_FILE="data/.env"
+
+# Validate the JSON file
+if ! jq empty "$JSON_FILE" 2>/dev/null; then
+    echo "Invalid JSON file: $JSON_FILE"
+    exit 1
+fi
+
+# Read JSON and append keys and values to .env
+jq -r 'to_entries | map("\(.key)=\(.value|tostring)") | .[]' "$JSON_FILE" >> "$OUTPUT_FILE"
+
+echo "Environment variables written to $OUTPUT_FILE"

--- a/deps/scripts/update_config.sh
+++ b/deps/scripts/update_config.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+source data/.env
+
+# Check for required arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <target_yaml_file> <mode>"
+    echo "Modes: bootstrapper_l1, bootstrapper_l2, madara"
+    exit 1
+fi
+
+TARGET_FILE="$1"
+MODE="$2"
+
+# Ensure the target file exists
+if [ ! -f "$TARGET_FILE" ]; then
+    echo "Error: Target file $TARGET_FILE not found."
+    exit 1
+fi
+
+# Update Bootstrapper verifier address
+if [ "$MODE" == "bootstrapper_l1" ]; then
+    # Ensure the environment variable is set
+    if [ -z "$verifier_address" ]; then
+        echo "Error: verifier_address environment variable is not set."
+        exit 1
+    fi
+
+    # Use jq to replace verifier_address
+    jq --arg new_verifier "$verifier_address" '.verifier_address = $new_verifier' "$TARGET_FILE" > tmpfile && mv tmpfile "$TARGET_FILE"
+
+    echo "Updated verifier_address in $TARGET_FILE"
+    exit 0
+fi
+
+# Update Bootstrapper core contract address
+if [ "$MODE" == "bootstrapper_l2" ]; then
+    # Ensure the environment variable is set
+    if [ -z "$starknet_contract_address" ] || [ -z "$starknet_contract_implementation_address" ]; then
+        echo "Error: starknet_contract_address and starknet_contract_implementation_address environment variables must be set."
+        exit 1
+    fi
+
+    # Use jq to replace core contract address
+    jq --arg new_value "$starknet_contract_address" '.core_contract_address = $new_value' "$TARGET_FILE" > tmpfile && mv tmpfile "$TARGET_FILE"
+
+    # Use jq to replace core contract implementation address
+    jq --arg new_value "$starknet_contract_implementation_address" '.core_contract_implementation_address = $new_value' "$TARGET_FILE" > tmpfile && mv tmpfile "$TARGET_FILE"
+
+    echo "Updated verifier_address in $TARGET_FILE"
+    exit 0
+fi
+
+# Update Madara core contract and verifier address
+if [ "$MODE" == "madara" ]; then
+    # Ensure required environment variables are set
+    if [ -z "$starknet_contract_address" ] || [ -z "$verifier_address" ]; then
+        echo "Error: starknet_contract_address and verifier_address environment variables must be set."
+        exit 1
+    fi
+
+    # Replace core contract address and verifier address
+    awk -v new_eth_core="$starknet_contract_address" -v new_verifier="$verifier_address" '
+    /^\s*eth_core_contract_address:/ {
+        print "eth_core_contract_address: " new_eth_core;
+        next;
+    }
+    /^\s*eth_gps_statement_verifier:/ {
+        print "eth_gps_statement_verifier: " new_verifier;
+        next;
+    }
+    { print }
+    ' "$TARGET_FILE" > tmpfile && mv tmpfile "$TARGET_FILE"
+
+    echo "Updated eth_core_contract_address and eth_gps_statement_verifier in $TARGET_FILE"
+    exit 0
+fi
+
+# Invalid mode handling
+echo "Error: Invalid mode '$MODE'."
+echo "Available modes: bootstrapper, madara, tbd"
+exit 1


### PR DESCRIPTION
Dump output from Bootstrapper (L1 and L2) and Mock verifier deploy steps into an env file
Propagate these addresses (so far core contract and verifier) to all the services that use them
Adapt Orchestrator Dockerfile to build mono-repo main branch

With these changes, the user is able to modify ETH wallet params and set a different ETH private key in the CLI.
The CLI will propagate the new contract addresses and AppChain mode will continue working as expected
```
# ETH wallet
[eth_wallet]
# ETH private key that will be used to sign transactions for contracts deployment
eth_priv_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
# ETH address derived from eth_priv_key
l1_deployer_address = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
# ETH address that will be the owner from the proxy
l1_operator_address = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
# L1 multisig address: a secondary address (must be different from L1 deployer address)
l1_multisig_address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
```